### PR TITLE
Add rewards tracker dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,493 @@
+const dispensaries = [
+  {
+    id: "rise",
+    name: "RISE Dispensary",
+    logo: "https://i.postimg.cc/28bbBJmD/RISE-Cannabis.png",
+    description: "1 point earned per $1 spent across Mechanicsburg, Steelton, and Carlisle.",
+    locations: [
+      {
+        name: "Mechanicsburg",
+        url: "https://risecannabis.com/dispensaries/pennsylvania/mechanicsburg/1550/medical-menu/",
+      },
+      {
+        name: "Steelton",
+        url: "https://risecannabis.com/dispensaries/pennsylvania/steelton/1544/medical-menu/",
+      },
+      {
+        name: "Carlisle",
+        url: "https://risecannabis.com/dispensaries/pennsylvania/carlisle/1547/medical-menu/",
+      },
+    ],
+    initialPoints: 1637,
+    redemptionOptions: Array.from({ length: 33 }, (_, i) => ({
+      points: (i + 1) * 100,
+      value: 3 * (i + 1),
+    })),
+    quickButtons: [100, 200, 300, 400, 500, 800, 1000, 1200, 1500, 2000, 2500, 3000],
+    earnPoints({ amount }) {
+      return Math.floor(amount);
+    },
+    calculateRewardValue(points) {
+      return (points / 100) * 3;
+    },
+    validateRedemption(points) {
+      return points % 100 === 0;
+    },
+    redemptionHint: "Redeem in 100 point steps ($3 value each).",
+  },
+  {
+    id: "organic",
+    name: "Organic Remedies",
+    logo: "https://i.postimg.cc/05HKjvTn/Organic-Remedies.png",
+    description: "1 point per $1 spent at any Organic Remedies location.",
+    initialPoints: 0,
+    redemptionOptions: [
+      { points: 250, value: 15 },
+      { points: 500, value: 30 },
+      { points: 750, value: 45 },
+      { points: 1000, value: 60 },
+    ],
+    quickButtons: [250, 500, 750, 1000],
+    earnPoints({ amount }) {
+      return Math.floor(amount);
+    },
+    calculateRewardValue(points) {
+      return points * 0.06;
+    },
+    validateRedemption(points) {
+      return points % 250 === 0;
+    },
+    redemptionHint: "Redeem in 250 point steps ($15 value each).",
+  },
+  {
+    id: "fluent",
+    name: "FLUENT",
+    logo: "https://i.postimg.cc/5yGXR5BT/FLUENT.png",
+    description: "Earn 1 point per $20 spent. Wednesday purchases earn triple points. Points redeem $1 each.",
+    initialPoints: 0,
+    redemptionOptions: [
+      { points: 1, value: 1 },
+    ],
+    quickButtons: [],
+    earnPoints({ amount, isWednesday }) {
+      const base = Math.floor(amount / 20);
+      return isWednesday ? base * 3 : base;
+    },
+    calculateRewardValue(points) {
+      return points;
+    },
+    validateRedemption(points) {
+      return Number.isInteger(points) && points >= 0;
+    },
+    redemptionHint: "Each point equals $1 off your order.",
+  },
+  {
+    id: "trulieve",
+    name: "Trulieve",
+    logo: "https://i.postimg.cc/kX0VNcXt/Trulieve.png",
+    description: "1 point earned per $1 spent. Redeem for tiered rewards.",
+    initialPoints: 287,
+    redemptionOptions: [
+      { points: 100, value: 5 },
+      { points: 250, value: 15 },
+      { points: 500, value: 35 },
+      { points: 1000, value: 75 },
+      { points: 2000, value: 160 },
+    ],
+    quickButtons: [100, 250, 500, 1000, 2000],
+    earnPoints({ amount }) {
+      return Math.floor(amount);
+    },
+    calculateRewardValue(points) {
+      const tier = this.redemptionOptions.find((option) => option.points === points);
+      if (tier) return tier.value;
+      // Interpolate for non-tier values by using the best lesser tier value per point.
+      const eligible = this.redemptionOptions.filter((option) => option.points <= points);
+      if (!eligible.length) return 0;
+      const best = eligible.reduce((highest, option) => {
+        const valuePerPoint = option.value / option.points;
+        return valuePerPoint > highest.valuePerPoint ? { ...option, valuePerPoint } : highest;
+      }, { valuePerPoint: 0, value: 0, points: 0 });
+      return (points / best.points) * best.value;
+    },
+    validateRedemption(points) {
+      return this.redemptionOptions.some((option) => option.points === points);
+    },
+    redemptionHint: "Redeem using one of the available reward tiers.",
+  },
+];
+
+const storageKey = "rewards-tracker-state-v1";
+
+function getInitialState() {
+  const saved = localStorage.getItem(storageKey);
+  if (saved) {
+    try {
+      const parsed = JSON.parse(saved);
+      return dispensaries.reduce((acc, dispensary) => {
+        acc[dispensary.id] = {
+          points: parsed[dispensary.id]?.points ?? dispensary.initialPoints,
+          history: parsed[dispensary.id]?.history ?? [],
+        };
+        return acc;
+      }, {});
+    } catch (error) {
+      console.warn("Failed to parse saved state", error);
+    }
+  }
+  return dispensaries.reduce((acc, dispensary) => {
+    acc[dispensary.id] = { points: dispensary.initialPoints, history: [] };
+    return acc;
+  }, {});
+}
+
+const state = getInitialState();
+
+function persistState() {
+  localStorage.setItem(storageKey, JSON.stringify(state));
+}
+
+function formatCurrency(value) {
+  return `$${value.toFixed(2)}`;
+}
+
+function formatDate(dateString) {
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return dateString;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function isWednesday(dateString) {
+  const date = new Date(dateString + "T00:00:00");
+  return date.getDay() === 3;
+}
+
+function renderGrid() {
+  const grid = document.getElementById("dispensaryGrid");
+  grid.innerHTML = "";
+
+  dispensaries.forEach((dispensary) => {
+    const card = document.createElement("article");
+    card.className = "card";
+
+    const logo = document.createElement("img");
+    logo.className = "card-logo";
+    logo.src = dispensary.logo;
+    logo.alt = `${dispensary.name} logo`;
+
+    const name = document.createElement("h2");
+    name.className = "card-title";
+    name.textContent = dispensary.name;
+
+    const points = document.createElement("p");
+    points.className = "card-points";
+    points.textContent = `${state[dispensary.id].points.toLocaleString()} pts`;
+
+    const meta = document.createElement("div");
+    meta.className = "card-meta";
+    const metaLeft = document.createElement("span");
+    metaLeft.textContent = dispensary.description;
+    meta.append(metaLeft);
+
+    const button = document.createElement("button");
+    button.className = "primary-btn";
+    button.textContent = "Manage";
+    button.addEventListener("click", () => openModal(dispensary));
+
+    card.append(logo, name, points, meta, button);
+    grid.append(card);
+  });
+}
+
+function openModal(dispensary) {
+  document.querySelectorAll(".modal").forEach((modal) => closeModal(modal));
+  const modalTemplate = document.getElementById("modalTemplate");
+  const modalFragment = modalTemplate.content.cloneNode(true);
+  const modalElement = modalFragment.querySelector(".modal");
+  const modalContent = modalFragment.querySelector(".modal-content");
+  const closeButton = modalFragment.querySelector(".modal-close");
+  const backdrop = document.getElementById("modalBackdrop");
+
+  modalContent.dataset.dispensaryId = dispensary.id;
+  modalFragment.querySelector(".modal-logo").src = dispensary.logo;
+  modalFragment.querySelector(".modal-logo").alt = `${dispensary.name} logo`;
+  modalFragment.querySelector(".modal-title").textContent = dispensary.name;
+  modalFragment.querySelector(".modal-subtitle").textContent = dispensary.description;
+  modalFragment.querySelector(".points-value").textContent = `${state[
+    dispensary.id
+  ].points.toLocaleString()} pts`;
+
+  const helper = modalFragment.querySelector(".form-helper");
+  helper.textContent = dispensary.redemptionHint;
+
+  const tierContainer = modalFragment.querySelector(".tier-tags");
+  tierContainer.innerHTML = "";
+  (dispensary.redemptionOptions || []).forEach((option) => {
+    const tag = document.createElement("span");
+    tag.className = "tier-tag";
+    const rewardValue = option.value ? formatCurrency(option.value) : `${option.points} pts`;
+    tag.textContent = option.value
+      ? `${option.points} pts → ${rewardValue}`
+      : `${option.points} pts`;
+    if (state[dispensary.id].points >= option.points) {
+      tag.classList.add("active");
+    }
+    tierContainer.append(tag);
+  });
+
+  const locationContainer = modalFragment.querySelector(".location-links");
+  locationContainer.innerHTML = "";
+  if (dispensary.locations?.length) {
+    dispensary.locations.forEach((location) => {
+      const link = document.createElement("a");
+      link.href = location.url;
+      link.target = "_blank";
+      link.rel = "noreferrer";
+      link.className = "location-link";
+      link.textContent = location.name;
+      locationContainer.append(link);
+    });
+  } else {
+    locationContainer.remove();
+  }
+
+  const pointButtonsContainer = modalFragment.querySelector(".point-buttons");
+  pointButtonsContainer.innerHTML = "";
+  if (dispensary.quickButtons?.length) {
+    dispensary.quickButtons.forEach((value) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "point-button";
+      button.textContent = `${value.toLocaleString()} pts`;
+      button.addEventListener("click", () => {
+        const pointsInput = modalContent.querySelector('input[name="points"]');
+        const available = state[dispensary.id].points;
+        const safeValue = Math.min(value, available);
+        pointsInput.value = safeValue;
+        updateRedemptionHelper(dispensary, safeValue, helper);
+      });
+      pointButtonsContainer.append(button);
+    });
+    const maxButton = document.createElement("button");
+    maxButton.type = "button";
+    maxButton.className = "point-button";
+    maxButton.textContent = "Max";
+    maxButton.addEventListener("click", () => {
+      const pointsInput = modalContent.querySelector('input[name="points"]');
+      pointsInput.value = state[dispensary.id].points;
+      updateRedemptionHelper(dispensary, state[dispensary.id].points, helper);
+    });
+    pointButtonsContainer.append(maxButton);
+  } else {
+    const note = document.createElement("span");
+    note.className = "tier-tag";
+    note.textContent = "Use the input to enter any amount";
+    pointButtonsContainer.append(note);
+  }
+
+  const purchaseForm = modalFragment.querySelector(".purchase-form");
+  const dateInput = purchaseForm.querySelector('input[name="date"]');
+  const today = new Date();
+  const isoDate = today.toISOString().split("T")[0];
+  dateInput.value = isoDate;
+
+  purchaseForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(purchaseForm);
+    const amount = Number(formData.get("amount"));
+    const date = formData.get("date");
+    const points = Number(formData.get("points"));
+
+    if (!date) {
+      helper.textContent = "Please select the purchase date.";
+      helper.classList.add("error");
+      return;
+    }
+
+    if (Number.isNaN(amount) || amount <= 0) {
+      helper.textContent = "Enter a purchase amount greater than zero.";
+      helper.classList.add("error");
+      return;
+    }
+
+    if (points > state[dispensary.id].points) {
+      helper.textContent = "You cannot redeem more points than you have.";
+      helper.classList.add("error");
+      return;
+    }
+
+    if (points < 0 || !dispensary.validateRedemption(points)) {
+      helper.textContent = "Adjust the points to match the redemption rules.";
+      helper.classList.add("error");
+      return;
+    }
+
+    const earned = dispensary.earnPoints({ amount, isWednesday: isWednesday(date) });
+    const discount = dispensary.calculateRewardValue(points);
+
+    state[dispensary.id].points = state[dispensary.id].points + earned - points;
+    state[dispensary.id].history.unshift({
+      date,
+      amount,
+      pointsEarned: earned,
+      pointsRedeemed: points,
+      discount,
+    });
+
+    persistState();
+    renderGrid();
+    refreshModal(modalContent, dispensary);
+    helper.textContent = `Added purchase. Earned ${earned} pts${
+      points ? `, redeemed ${points} pts (${formatCurrency(discount)}).` : "."
+    }`;
+    helper.classList.remove("error");
+    purchaseForm.reset();
+    dateInput.value = isoDate;
+    purchaseForm.querySelector('input[name="points"]').value = 0;
+    updateRedemptionHelper(dispensary, 0, helper);
+  });
+
+  const pointsInput = modalFragment.querySelector('input[name="points"]');
+  pointsInput.addEventListener("input", () => {
+    const value = Number(pointsInput.value) || 0;
+    if (value > state[dispensary.id].points) {
+      pointsInput.value = state[dispensary.id].points;
+    }
+    updateRedemptionHelper(dispensary, Number(pointsInput.value) || 0, helper);
+  });
+
+  const calculatorForm = modalFragment.querySelector(".calculator-form");
+  const calculatorResult = modalFragment.querySelector(".calculator-result");
+  calculatorForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const formData = new FormData(calculatorForm);
+    const planAmount = Number(formData.get("planAmount"));
+    let planPoints = Number(formData.get("planPoints"));
+
+    if (Number.isNaN(planAmount) || planAmount <= 0) {
+      calculatorResult.textContent = "Enter a valid purchase amount.";
+      return;
+    }
+
+    if (planPoints > state[dispensary.id].points) {
+      planPoints = state[dispensary.id].points;
+    }
+
+    if (planPoints < 0 || !dispensary.validateRedemption(planPoints)) {
+      calculatorResult.textContent = "Adjust the points to match the redemption rules.";
+      return;
+    }
+
+    const savings = dispensary.calculateRewardValue(planPoints);
+    const finalCost = Math.max(planAmount - savings, 0);
+    calculatorResult.innerHTML = `Using <strong>${planPoints.toLocaleString()} pts</strong> saves <strong>${formatCurrency(
+      savings
+    )}</strong>. Estimated total: <strong>${formatCurrency(finalCost)}</strong>.`;
+  });
+
+  renderHistory(modalFragment.querySelector(".history"), dispensary);
+
+  closeButton.addEventListener("click", () => closeModal(modalElement));
+  modalElement.addEventListener("click", (event) => {
+    if (event.target === modalElement) {
+      closeModal(modalElement);
+    }
+  });
+  document.addEventListener(
+    "keydown",
+    (event) => {
+      if (event.key === "Escape") {
+        closeModal(modalElement);
+      }
+    },
+    { once: true }
+  );
+
+  document.body.append(modalFragment);
+  requestAnimationFrame(() => {
+    backdrop.classList.remove("hidden");
+    backdrop.classList.add("visible");
+  });
+}
+
+function refreshModal(modalContent, dispensary) {
+  modalContent.querySelector(".points-value").textContent = `${state[
+    dispensary.id
+  ].points.toLocaleString()} pts`;
+
+  const tierContainer = modalContent.querySelector(".tier-tags");
+  if (tierContainer) {
+    tierContainer.querySelectorAll(".tier-tag").forEach((tag, index) => {
+      const option = dispensary.redemptionOptions[index];
+      if (!option) return;
+      if (state[dispensary.id].points >= option.points) {
+        tag.classList.add("active");
+      } else {
+        tag.classList.remove("active");
+      }
+    });
+  }
+
+  const historySection = modalContent.querySelector(".history");
+  renderHistory(historySection, dispensary);
+}
+
+function renderHistory(historySection, dispensary) {
+  const list = historySection.querySelector(".history-list");
+  const empty = historySection.querySelector(".history-empty");
+  list.innerHTML = "";
+  const history = state[dispensary.id].history;
+  if (!history.length) {
+    empty.style.display = "block";
+    return;
+  }
+  empty.style.display = "none";
+
+  history.slice(0, 10).forEach((entry) => {
+    const item = document.createElement("li");
+    item.className = "history-item";
+    const earnedText = `${entry.pointsEarned.toLocaleString()} pts earned`;
+    const redeemedText = entry.pointsRedeemed
+      ? `${entry.pointsRedeemed.toLocaleString()} pts used (${formatCurrency(entry.discount)})`
+      : "No points used";
+
+    item.innerHTML = `
+      <span>${formatDate(entry.date)} · ${formatCurrency(entry.amount)}</span>
+      <span>${earnedText}</span>
+      <span>${redeemedText}</span>
+    `;
+    list.append(item);
+  });
+}
+
+function updateRedemptionHelper(dispensary, points, helper) {
+  if (!helper) return;
+  if (points === 0) {
+    helper.textContent = dispensary.redemptionHint;
+    helper.classList.remove("error");
+    return;
+  }
+
+  if (!dispensary.validateRedemption(points)) {
+    helper.textContent = "This amount doesn't match the redemption rules.";
+    helper.classList.add("error");
+    return;
+  }
+
+  const discount = dispensary.calculateRewardValue(points);
+  helper.textContent = `${points.toLocaleString()} pts ≈ ${formatCurrency(discount)} in savings.`;
+  helper.classList.remove("error");
+}
+
+function closeModal(modalElement) {
+  const backdrop = document.getElementById("modalBackdrop");
+  modalElement?.remove();
+  backdrop.classList.remove("visible");
+  backdrop.classList.add("hidden");
+}
+
+renderGrid();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dispensary Rewards Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>Rewards Dashboard</h1>
+      <p class="subtitle">Track, plan, and maximize your dispensary perks</p>
+    </header>
+
+    <main>
+      <section class="card-grid" id="dispensaryGrid"></section>
+    </main>
+
+    <template id="modalTemplate">
+      <div class="modal" role="dialog" aria-modal="true">
+        <div class="modal-content">
+          <button class="modal-close" aria-label="Close">&times;</button>
+          <div class="modal-header">
+            <img class="modal-logo" alt="" />
+            <div>
+              <h2 class="modal-title"></h2>
+              <p class="modal-subtitle"></p>
+            </div>
+          </div>
+
+          <section class="points-summary">
+            <h3>Current balance</h3>
+            <p class="points-value"></p>
+            <div class="tier-tags"></div>
+            <div class="location-links"></div>
+          </section>
+
+          <section class="action-section">
+            <h3>Add a purchase</h3>
+            <form class="purchase-form">
+              <div class="form-grid">
+                <label>
+                  <span>Purchase amount ($)</span>
+                  <input type="number" name="amount" min="0" step="0.01" required />
+                </label>
+                <label>
+                  <span>Date</span>
+                  <input type="date" name="date" required />
+                </label>
+                <label class="points-field">
+                  <span>Points to redeem</span>
+                  <div class="points-input">
+                    <input
+                      type="number"
+                      name="points"
+                      min="0"
+                      step="1"
+                      value="0"
+                    />
+                    <div class="point-buttons" aria-label="Quick point buttons"></div>
+                  </div>
+                </label>
+              </div>
+              <button type="submit" class="primary-btn">Save purchase</button>
+              <p class="form-helper"></p>
+            </form>
+          </section>
+
+          <section class="calculator">
+            <h3>Cost planner</h3>
+            <form class="calculator-form">
+              <div class="form-grid">
+                <label>
+                  <span>Planned purchase ($)</span>
+                  <input type="number" name="planAmount" min="0" step="0.01" required />
+                </label>
+                <label>
+                  <span>Points to apply</span>
+                  <input type="number" name="planPoints" min="0" step="1" value="0" />
+                </label>
+              </div>
+              <button type="submit" class="secondary-btn">Calculate</button>
+            </form>
+            <p class="calculator-result" role="status"></p>
+          </section>
+
+          <section class="history">
+            <h3>Recent activity</h3>
+            <div class="history-empty">No purchases yet.</div>
+            <ul class="history-list"></ul>
+          </section>
+        </div>
+      </div>
+    </template>
+
+    <div class="backdrop hidden" id="modalBackdrop"></div>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,428 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-elevated: #273349;
+  --surface-hover: #31415c;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #f87171;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.15), transparent 40%),
+    var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.app-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.app-header h1 {
+  font-size: clamp(2rem, 2.6vw, 2.75rem);
+  margin: 0 0 0.25rem;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.card-grid {
+  width: min(1100px, 100%);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.95));
+  border-radius: 18px;
+  padding: 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 40px rgba(8, 15, 35, 0.35);
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.25), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.card-logo {
+  height: 48px;
+  width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.65));
+}
+
+.card-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.card-points {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.card-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.card button {
+  align-self: flex-start;
+}
+
+.primary-btn,
+.secondary-btn {
+  border-radius: 999px;
+  border: none;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #0f172a;
+  box-shadow: 0 10px 30px rgba(14, 165, 233, 0.35);
+}
+
+.primary-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 35px rgba(14, 165, 233, 0.45);
+}
+
+.secondary-btn {
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--text);
+}
+
+.secondary-btn:hover {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 3rem 1.5rem;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.modal-content {
+  background: var(--surface);
+  border-radius: 24px;
+  width: min(720px, 100%);
+  padding: 2.5rem;
+  box-shadow: 0 30px 60px rgba(8, 15, 35, 0.45);
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.modal-close {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 1.75rem;
+  cursor: pointer;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.modal-logo {
+  height: 56px;
+  width: 56px;
+  object-fit: contain;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.45);
+  padding: 0.5rem;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.modal-subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.points-summary {
+  background: var(--surface-elevated);
+  border-radius: 18px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.points-summary h3 {
+  margin: 0 0 0.75rem;
+  font-weight: 600;
+}
+
+.points-value {
+  font-size: 2.4rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+.tier-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.location-links {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.location-link {
+  font-size: 0.85rem;
+  color: var(--accent);
+  text-decoration: none;
+  background: rgba(56, 189, 248, 0.12);
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.location-link:hover {
+  background: rgba(56, 189, 248, 0.22);
+  color: var(--accent-strong);
+}
+
+.tier-tag {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.tier-tag.active {
+  background: rgba(52, 211, 153, 0.2);
+  color: var(--success);
+  border: 1px solid rgba(52, 211, 153, 0.4);
+}
+
+.action-section,
+.calculator,
+.history {
+  margin-bottom: 2rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+label span {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 0.4rem;
+}
+
+input[type="number"],
+input[type="date"] {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+input[type="number"]:focus,
+input[type="date"]:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.35);
+  border-color: transparent;
+}
+
+.points-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.point-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.point-button {
+  border-radius: 10px;
+  background: rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 0.4rem 0.85rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--text);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.point-button:hover {
+  background: rgba(56, 189, 248, 0.2);
+  transform: translateY(-1px);
+}
+
+.form-helper {
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.form-helper.error {
+  color: var(--danger);
+}
+
+.calculator-result {
+  margin-top: 0.75rem;
+  color: var(--text-muted);
+  min-height: 1.2rem;
+}
+
+.calculator-result strong {
+  color: var(--accent);
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.history-item {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1fr;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.history-item span:nth-child(2) {
+  text-align: right;
+}
+
+.history-item span:nth-child(3) {
+  text-align: right;
+  color: var(--text-muted);
+}
+
+.history-empty {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(6px);
+  z-index: 5;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+}
+
+.backdrop.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  .modal {
+    padding: 1.25rem;
+  }
+
+  .modal-content {
+    padding: 1.75rem;
+  }
+
+  .history-item {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .history-item span:nth-child(2),
+  .history-item span:nth-child(3) {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- build a dark-themed rewards dashboard landing page with cards for each dispensary
- add modals for managing balances, logging purchases, and previewing savings scenarios per brand
- implement localStorage-backed state with reward-specific earning, redemption, and history handling

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d59e121d588322a9c73a2faf81987a